### PR TITLE
Clean latex special characters for bookdown labels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,10 @@ Authors@R:
       person(given = "Ellis",
              family = "Valentiner",
              role = "ctb"),
+      person(given = "Martin",
+             family = "Hadley",
+             role = "ctb",
+             comment = c(ORCID = "0000-0002-3039-6849")),
       person(given = "Locke Data",
              role = "fnd",
              comment = "https://itsalocke.com"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # dev version
 
 * The regex recognizing the beginning of a chunk now demands ``` are at the beginning of a line (@gorkang, #17).
+* Replace LaTeX special characters with `-` to better support text references in bookdown.
 
 # namer 0.1.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # dev version
 
 * The regex recognizing the beginning of a chunk now demands ``` are at the beginning of a line (@gorkang, #17).
-* Replace LaTeX special characters with `-` to better support text references in bookdown.
+* Replace LaTeX special characters with `-` to better support text references in bookdown @martinjhnhadley
 
 # namer 0.1.3
 

--- a/R/name_chunks.R
+++ b/R/name_chunks.R
@@ -45,6 +45,9 @@ name_chunks <- function(path){
     # create new chunk names
     filename <- fs::path_ext_remove(path)
     filename <- fs::path_file(filename)
+    # support for bookdown text references by removing underscores
+    # https://bookdown.org/yihui/bookdown/markdown-extensions-by-bookdown.html#fnref5
+    filename <- clean_latex_special_characters(filename)
     new_chunk_names <-  glue::glue("{filename}-{1:no_unnamed}")
     new_chunk_names <- as.character(new_chunk_names)
     # and write to which line they correspond

--- a/R/utils.R
+++ b/R/utils.R
@@ -98,5 +98,21 @@ quote_label = function(x) {
   x
 }
 
+# from knitr:::escape_latex()
+clean_latex_special_characters <- function (x, newlines = FALSE, spaces = FALSE)
+{
+  x <- gsub("\\\\", "-", x)
+  x <- gsub("([#$%&_{}])", "-", x)
+  x <- gsub("\\\\textbackslash", "-", x)
+  x <- gsub("~", "-", x)
+  x <- gsub("\\^", "-", x)
+  x <- gsub("(?<!\n)\n(?!\n)", "-", x, perl = TRUE)
+  x <- gsub("  ", "-", x)
+  x <- gsub("\\s", "-", x)
+  x <- gsub("[-]{2,}", "-", x)
+  x
+}
+
+
 
 globalVariables(".data")

--- a/tests/testthat/test-name_chunks.R
+++ b/tests/testthat/test-name_chunks.R
@@ -2,6 +2,16 @@ context("test-name_chunks")
 
 tmp <- tempdir()
 
+test_that("LaTeX special characters are succesfully replaced in filenames", {
+
+  bad_filename <- "11-12-2018_The-%-of-$-on-this-&-that"
+
+  fixed_filename <- clean_latex_special_characters(bad_filename)
+
+  expect_false(grepl("([#$%&_{}])|\\s|~|\\^|[-]{2,}", paste0(fixed_filename, "")))
+
+})
+
 test_that("renaming works", {
   temp_file_path <- file.path(tmp, "test.Rmd")
 


### PR DESCRIPTION
Bookdown provides support for captions and other internal referencing via the use of chunk names. 

As warned here https://bookdown.org/yihui/bookdown/markdown-extensions-by-bookdown.html#text-references it's advised not to use underscores in chunk labels as they're escaped in LateX

Jenny Bryan's excellent "how to name files" slide deck https://speakerdeck.com/jennybc/how-to-name-files encourages the following:

YYYY-MM-DD_semantic-component-1_component-2

This PR introduces `clean_latex_special_characters` which replaces all LaTeX special characters in filenames with - and also removes duplicate dashes.